### PR TITLE
docs: Update install instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.swp
+.vscode

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ Install
 Download, review, then execute the script:
 
 ```sh
-curl --remote-name https://raw.githubusercontent.com/thoughtbot/laptop/master/mac
+git clone git@github.com:sparkbox/laptop.git
+cd laptop
 less mac
 sh mac 2>&1 | tee ~/laptop.log
 ```


### PR DESCRIPTION
The `curl` command in the README was pointing at the Thoughtbot version, also, since we added `node-versions.rb`, you need to get more than just the `mac` script.