### PR TITLE
Only install supported node versions

### DIFF
--- a/node-versions.rb
+++ b/node-versions.rb
@@ -6,5 +6,8 @@ require 'date'
 
 url = URI('https://raw.githubusercontent.com/nodejs/Release/master/schedule.json')
 result = Net::HTTP.get(url)
-lts = JSON.parse(result).select {|key, value| value.key?("lts") and Date.parse(value["start"]) < Date.today }
-lts.each {|key, value| puts "node@#{key.gsub(/v/, '')}" }
+lts = JSON
+  .parse(result)
+  .select {|key, value| value.key?("lts") and Date.parse(value["start"]) < Date.today }
+  .select {|key, value| value.key?("lts") and Date.parse(value["end"]) > Date.today }
+  .each {|key, value| puts "node@#{key.gsub(/v/, '')}" }


### PR DESCRIPTION
Node 4 is no longer supported by the Node organization and has been pulled from brew. This ensures we only install those version of node that are still supported at this time.