### PR TITLE
fix: homebrew toolbelt and remove EOLed PHP

### DIFF
--- a/mac
+++ b/mac
@@ -167,6 +167,8 @@ brew link --force $mostrecentnode
 
 # Cleanup after old packages
 brew_uninstall 'mysql'
+brew_uninstall 'php56'
+brew_uninstall 'php70'
 
 brew_install_or_upgrade 'zsh'
 brew_install_or_upgrade 'git'

--- a/mac
+++ b/mac
@@ -190,7 +190,8 @@ brew cask install firefox
 brew cask install google-chrome
 brew cask install sequel-pro
 brew cask install 1password
-brew_install_or_upgrade 'heroku-toolbelt'
+brew tap heroku/brew
+brew_install_or_upgrade 'heroku/brew/heroku'
 
 # Install PHP with FPM for use with the Sparkbox Standard Apache setup
 . ./php.sh

--- a/php.sh
+++ b/php.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-php_versions=("5.6" "7.0" "7.1" "7.2")
+php_versions=("7.1" "7.2")
 
 for version in ${php_versions[*]}; do
   formula="php@$version"


### PR DESCRIPTION
### Description

- Fixes homebrew path/name for heroku and uses heroku's tap to install toolbelt
- Removes and uninstalls dead versions of PHP

### Test

Run the laptop script to test.