### PR TITLE
docs: change git clone to https:// link

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Install
 Download, review, then execute the script:
 
 ```sh
-git clone git@github.com:sparkbox/laptop.git
+git clone https://github.com/sparkbox/laptop.git
 cd laptop
 less mac
 sh mac 2>&1 | tee ~/laptop.log


### PR DESCRIPTION
I ran into a little snag while setting up a new laptop (running Mojave).

Using `git clone git@github.com:sparkbox/laptop.git` didn't work for a fresh install. The `https://` link did.